### PR TITLE
Move pipelines to prod

### DIFF
--- a/airtable_to_bq.py
+++ b/airtable_to_bq.py
@@ -29,8 +29,7 @@ from airflow.providers.google.cloud.transfers.gcs_to_bigquery import (
     GCSToBigQueryOperator,
 )
 from dataloader.airflow_utils.defaults import (
-    DEV_DATA_BUCKET,
-    GCP_ZONE,
+    DATA_BUCKET,
     PROJECT_ID,
     get_default_args,
     get_post_success,
@@ -48,7 +47,7 @@ def create_dag(dagname: str, config: dict) -> DAG:
     :param config: Pipeline configuration
     :return: Dag that runs a scraper
     """
-    bucket = DEV_DATA_BUCKET
+    bucket = DATA_BUCKET
     staging_dataset = f"staging_{DATASET}"
     sql_dir = f"sql/{DATASET}/{config['name']}"
     schema_dir = f"schemas/{DATASET}/{config['name']}"

--- a/bq_to_airtable.py
+++ b/bq_to_airtable.py
@@ -29,8 +29,7 @@ from airflow.providers.google.cloud.transfers.gcs_to_bigquery import (
     GCSToBigQueryOperator,
 )
 from dataloader.airflow_utils.defaults import (
-    DEV_DATA_BUCKET,
-    GCP_ZONE,
+    DATA_BUCKET,
     PROJECT_ID,
     get_default_args,
     get_post_success,
@@ -48,7 +47,7 @@ def create_dag(dagname: str, config: dict) -> DAG:
     :param config: Pipeline configuration
     :return: Dag that runs a scraper
     """
-    bucket = DEV_DATA_BUCKET
+    bucket = DATA_BUCKET
     staging_dataset = f"staging_{DATASET}"
     sql_dir = f"sql/{DATASET}/{config['name']}"
     tmp_dir = f"{DATASET}/{config['name']}/tmp"

--- a/push_to_airflow.sh
+++ b/push_to_airflow.sh
@@ -1,4 +1,4 @@
-gsutil rm -r gs://us-east1-dev2023-cc1-b088c7e1-bucket/dags/airtable_scripts
-gsutil -m cp -r airtable_scripts gs://us-east1-dev2023-cc1-b088c7e1-bucket/dags/
-gsutil cp bq_to_airtable.py gs://us-east1-dev2023-cc1-b088c7e1-bucket/dags/
-gsutil cp airtable_to_bq.py gs://us-east1-dev2023-cc1-b088c7e1-bucket/dags/
+gsutil rm -r gs://us-east1-production2023-cc1-01d75926-bucket/dags/airtable_scripts
+gsutil -m cp -r airtable_scripts gs://us-east1-production2023-cc1-01d75926-bucket/dags/
+gsutil cp bq_to_airtable.py gs://us-east1-production2023-cc1-01d75926-bucket/dags/
+gsutil cp airtable_to_bq.py gs://us-east1-production2023-cc1-01d75926-bucket/dags/


### PR DESCRIPTION
Will be useful if the dev environment continues to be troublesome. 

This will require updating the prod environment to use pypi package `more-itertools >=9.0.0`. I tried making this update but it didn't go through because of version mismatches between various packages; the logs are at `gcloud builds log c9ab3918-1690-44cf-962e-65e18dc69ae8 --project gcp-cset-projects`

```
+ [[ -z fail ]]
+ python3 -m pip check
apache-airflow-providers-snowflake 4.3.1 has requirement apache-airflow>=2.4.0, but you have apache-airflow 2.3.3+composer.
apache-airflow-providers-slack 7.3.1 has requirement apache-airflow>=2.4.0, but you have apache-airflow 2.3.3+composer.
apache-airflow-providers-sftp 4.4.0 has requirement apache-airflow>=2.4.0, but you have apache-airflow 2.3.3+composer.
apache-airflow-providers-common-sql 1.6.0 has requirement apache-airflow>=2.4.0, but you have apache-airflow 2.3.3+composer.
apache-airflow-providers-amazon 8.3.1 has requirement apache-airflow>=2.4.0, but you have apache-airflow 2.3.3+composer.
The command '/bin/sh -c bash installer.sh $COMPOSER_PYTHON_VERSION  fail' returned a non-zero code: 1
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
```