### PR TITLE
Add raise_for_status call to catch request errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     -   id: black
         language_version: python3
 -   repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.1.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/sqlfluff/sqlfluff

--- a/airtable_scripts/utils.py
+++ b/airtable_scripts/utils.py
@@ -156,6 +156,7 @@ def get_airtable_iter(
             f"https://api.airtable.com/v0/{base_id}/{table_name}{query}",
             headers=headers,
         )
+        result.raise_for_status()
         data = result.json()
         for row in data["records"]:
             content = row["fields"]

--- a/airtable_to_bq.py
+++ b/airtable_to_bq.py
@@ -44,7 +44,7 @@ def update_staging(dag: DAG, start_task, config: dict):
     name = config["name"]
     sql_dir = f"sql/{DATASET}/{config.get('parent_name', name)}"
     schema_dir = f"schemas/{DATASET}/{config.get('parent_name', name)}"
-    tmp_dir = f"{DATASET}/{name if 'parent_name' not in config else config['parent_name']+'_'+name}/tmp"
+    tmp_dir = f"{DATASET}/{name if 'parent_name' not in config else config['parent_name'] + '_' + name}/tmp"
     with dag:
         clear_tmp_dir = GCSDeleteObjectsOperator(
             task_id=f"clear_tmp_dir_{name}", bucket_name=bucket, prefix=tmp_dir

--- a/bq_to_airtable.py
+++ b/bq_to_airtable.py
@@ -42,7 +42,7 @@ def update_airtable(dag: DAG, start_task, end_task, config: dict):
     bucket = DATA_BUCKET
     name = config["name"]
     sql_dir = f"sql/{DATASET}/{config.get('parent_name', name)}"
-    tmp_dir = f"{DATASET}/{name if 'parent_name' not in config else config['parent_name']+'_'+name}/tmp"
+    tmp_dir = f"{DATASET}/{name if 'parent_name' not in config else config['parent_name'] + '_' + name}/tmp"
     with dag:
         clear_tmp_dir = GCSDeleteObjectsOperator(
             task_id=f"clear_tmp_dir_{name}", bucket_name=bucket, prefix=tmp_dir


### PR DESCRIPTION
When retrieving data from an Airflow table, so we get more informative error messages in Airtable task failures.