### PR TITLE
adding actions workflow for push-to-airflow

### DIFF
--- a/.github/workflows/push-to-airflow.yml
+++ b/.github/workflows/push-to-airflow.yml
@@ -1,0 +1,25 @@
+name: Push to Airflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push_to_airflow:
+    name: Run push_to_airflow.sh
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/855475113448/locations/global/workloadIdentityPools/eto-github/providers/eto-github'
+          service_account: 'eto-artifact-registry-github@gcp-cset-projects.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      - name: Run push_to_airflow.sh
+        run: |
+          chmod +x ./push_to_airflow.sh
+          ./push_to_airflow.sh


### PR DESCRIPTION
Every time something gets changed in this repo, [push_to_airflow.sh ](https://github.com/georgetown-cset/airtable-etl/blob/main/push_to_airflow.sh) needs to be run as well so that the corresponding code in the Dags folder gets updated. This will let us manually run push_to_airflow.sh via an actions workflow and see when it was last run and which branch it was run on. The UI will have a dropdown to select a branch.

We can also update this later to also automatically run push_to_airflow.sh when merging to main
