### PR TITLE
adding token permission to github

### DIFF
--- a/.github/workflows/push-to-airflow.yml
+++ b/.github/workflows/push-to-airflow.yml
@@ -17,13 +17,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        id: auth
+        uses: google-github-actions/auth@v2 # takes the Github token and gets a Google token
         with:
           workload_identity_provider: 'projects/855475113448/locations/global/workloadIdentityPools/eto-github/providers/eto-github'
           service_account: 'eto-artifact-registry-github@gcp-cset-projects.iam.gserviceaccount.com'
           token_format: 'access_token'
 
       - name: Run push_to_airflow.sh
+        env:
+            GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }} # gsutil will use the Google token to authenticate
         run: |
           chmod +x ./push_to_airflow.sh
           ./push_to_airflow.sh

--- a/.github/workflows/push-to-airflow.yml
+++ b/.github/workflows/push-to-airflow.yml
@@ -25,6 +25,8 @@ jobs:
           token_format: 'access_token'
 
       - name: Testing Authentication (temporary will delete later)
+        env:
+            GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }} # gsutil will use the Google token to authenticate
         run: |
           echo "Testing auth"
           gcloud auth list

--- a/.github/workflows/push-to-airflow.yml
+++ b/.github/workflows/push-to-airflow.yml
@@ -24,6 +24,13 @@ jobs:
           service_account: 'eto-artifact-registry-github@gcp-cset-projects.iam.gserviceaccount.com'
           token_format: 'access_token'
 
+      - name: Testing Authentication (temporary will delete later)
+        run: |
+          echo "Testing auth"
+          gcloud auth list
+          echo "Dags folder:"
+          gsutil ls gs://us-east1-production-cc2-202-b42a7a54-bucket
+
       - name: Run push_to_airflow.sh
         env:
             GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }} # gsutil will use the Google token to authenticate

--- a/.github/workflows/push-to-airflow.yml
+++ b/.github/workflows/push-to-airflow.yml
@@ -8,6 +8,10 @@ jobs:
     name: Run push_to_airflow.sh
     runs-on: ubuntu-latest
 
+    permissions:
+        contents: 'read' # lets the workflow read our code
+        id-token: 'write' # lets the workflow ask GitHub for a temporary token to log in to Google Cloud
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Granting github permission to use a token to temporarily authenticate to GCP. The default for private repos is 'none'